### PR TITLE
fix: pin down kubectl version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 CWD=$(pwd)
 
 echo "Installing kubectl"
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+curl -LO https://dl.k8s.io/release/v1.23.6/bin/linux/amd64/kubectl
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 export NVM_DIR=$HOME/.nvm;


### PR DESCRIPTION
fixes aws eks update-kubeconfig invalid apiVersion https://github.com/aws/aws-cli/issues/6920
