### PR TITLE
removed error stack from HttpException to avoid pod restart

### DIFF
--- a/services/application/apps/order/src/orders/orders.service.ts
+++ b/services/application/apps/order/src/orders/orders.service.ts
@@ -40,7 +40,7 @@ export class OrdersService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -73,7 +73,7 @@ export class OrdersService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -107,7 +107,7 @@ export class OrdersService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );

--- a/services/application/apps/product/src/products/products.service.ts
+++ b/services/application/apps/product/src/products/products.service.ts
@@ -41,7 +41,7 @@ export class ProductsService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -67,7 +67,7 @@ export class ProductsService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -93,7 +93,7 @@ export class ProductsService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -135,7 +135,7 @@ export class ProductsService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );

--- a/services/application/apps/user/src/users/users.service.ts
+++ b/services/application/apps/user/src/users/users.service.ts
@@ -34,7 +34,7 @@ export class UsersService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -80,7 +80,7 @@ export class UsersService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );

--- a/services/shared/apps/tenant-management/src/tenants/tenants.service.ts
+++ b/services/shared/apps/tenant-management/src/tenants/tenants.service.ts
@@ -30,7 +30,7 @@ export class TenantsService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -75,7 +75,7 @@ export class TenantsService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );

--- a/services/shared/apps/tenant-registration/src/registration/registration.service.ts
+++ b/services/shared/apps/tenant-registration/src/registration/registration.service.ts
@@ -40,7 +40,7 @@ export class RegistrationService {
       throw new HttpException(
         {
           status: HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error,
+          error: 'Something went wrong',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed error handling on services since de-serializing the error message from the AWS SDK was causing nest to crash and pods to restart. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
