### PR TITLE
now unconditionally exports CFN outputs

### DIFF
--- a/scripts/setenv-admin.sh
+++ b/scripts/setenv-admin.sh
@@ -2,7 +2,7 @@
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+export STACKS=$(aws cloudformation describe-stacks)
 export USERPOOLID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminUserPoolId") | .OutputValue')
 export APPCLIENTID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminAppClientId") | .OutputValue')
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')

--- a/scripts/setenv-application.sh
+++ b/scripts/setenv-application.sh
@@ -2,6 +2,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+export STACKS=$(aws cloudformation describe-stacks)
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')
 export ELBURL=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="ELBURL") | .OutputValue')

--- a/scripts/setenv-order.sh
+++ b/scripts/setenv-order.sh
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+STACKS=$(aws cloudformation describe-stacks)
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')
 export COGNITO_USER_POOL_ID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="PooledTenantUserPoolId") | .OutputValue')
 export COGNITO_CLIENT_ID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="PooledTenantAppClientId") | .OutputValue')

--- a/scripts/setenv-product.sh
+++ b/scripts/setenv-product.sh
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+export STACKS=$(aws cloudformation describe-stacks)
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')
 export COGNITO_USER_POOL_ID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="PooledTenantUserPoolId") | .OutputValue')
 export COGNITO_CLIENT_ID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="PooledTenantAppClientId") | .OutputValue')

--- a/scripts/setenv-tenant-management.sh
+++ b/scripts/setenv-tenant-management.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT-0
 
 
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+export STACKS=$(aws cloudformation describe-stacks)
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')
 export COGNITO_USER_POOL_ID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminUserPoolId") | .OutputValue')
 export COGNITO_CLIENT_ID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminAppClientId") | .OutputValue')

--- a/scripts/setenv-tenant-registration.sh
+++ b/scripts/setenv-tenant-registration.sh
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+export STACKS=$(aws cloudformation describe-stacks)
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')
 export USERPOOLID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminUserPoolId") | .OutputValue')
 export APPCLIENTID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminAppClientId") | .OutputValue')

--- a/scripts/setenv-user-management.sh
+++ b/scripts/setenv-user-management.sh
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-if [ -z "$STACKS" ]; then export STACKS=$(aws cloudformation describe-stacks);fi
+export STACKS=$(aws cloudformation describe-stacks)
 export REGION=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AWSRegion") | .OutputValue')
 export USERPOOLID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminUserPoolId") | .OutputValue')
 export APPCLIENTID=$(echo $STACKS | jq -r '.Stacks[]?.Outputs[]? | select(.OutputKey=="AdminAppClientId") | .OutputValue')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `$STACKS` variable is mutated, at times, throughout the deployment process. Previously, we would check for the existence of this variable and if it was there, use it to plug CloudFormation outputs. Depending on the state of the deployed stacks, however, the variable might not include all information. This change unconditionally re-exports the STACKS variable. It's a slight performance hit, but it ensures we have the ability to re-run these scripts and fix a partially deployed environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
