### PR TITLE
changing cluster name to correspond with buildspec.yml

### DIFF
--- a/cdk/eks/bin/eks.ts
+++ b/cdk/eks/bin/eks.ts
@@ -4,7 +4,7 @@ import { App } from 'aws-cdk-lib';
 import { EksStack } from '../lib/eks-stack';
 
 const app = new App();
-new EksStack(app, 'EksStack', {
+new EksStack(app, 'ClusterStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/scripts/on-your-own/deploy-eks.sh
+++ b/scripts/on-your-own/deploy-eks.sh
@@ -9,9 +9,9 @@ yarn && yarn run build
 cdk bootstrap  
 cdk deploy 
 
-export ELBURL=$(aws cloudformation describe-stacks --stack-name EksStack --query "Stacks[0].Outputs[?OutputKey=='ELBURL'].OutputValue" --output text)
-export CODEBUILD_ARN=$(aws cloudformation describe-stacks --stack-name EksStack --query "Stacks[0].Outputs[?OutputKey=='EksCodebuildArn'].OutputValue" --output text)
-export IAM_ROLE_ARN=$(aws cloudformation describe-stacks --stack-name EksStack --query "Stacks[0].Outputs[?OutputKey=='RoleUsedByTVM'].OutputValue" --output text)
+export ELBURL=$(aws cloudformation describe-stacks --stack-name ClusterStack --query "Stacks[0].Outputs[?OutputKey=='ELBURL'].OutputValue" --output text)
+export CODEBUILD_ARN=$(aws cloudformation describe-stacks --stack-name ClusterStack --query "Stacks[0].Outputs[?OutputKey=='EksCodebuildArn'].OutputValue" --output text)
+export IAM_ROLE_ARN=$(aws cloudformation describe-stacks --stack-name ClusterStack --query "Stacks[0].Outputs[?OutputKey=='RoleUsedByTVM'].OutputValue" --output text)
 
 echo "export ELBURL=${ELBURL}" | tee -a ~/.bash_profile
 echo "export IAM_ROLE_ARN=${IAM_ROLE_ARN}" | tee -a ~/.bash_profile


### PR DESCRIPTION
*Issue #, if available:*
Fixes #68 

*Description of changes:*
The "On Your Own" section of the workshop used an eks stack called "eks-stack". The CodePipeline that's run in response  to siloed tenant onboarding is expecting there to be a "ClusterStack", as is the case when doing the workshop at an AWS event. This change pulls the two versions into parity. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
